### PR TITLE
Due to security issues we discard using the remote_url method

### DIFF
--- a/app/models/no_cms/carrierwave/attachment.rb
+++ b/app/models/no_cms/carrierwave/attachment.rb
@@ -20,7 +20,7 @@ module NoCms::Carrierwave
     def dup
       new_attachment = super
       self.translations.each do |translation|
-        new_attachment.translation_for(translation.locale).remote_attachment_url = translation.attachment_url
+        new_attachment.translation_for(translation.locale).attachment = translation.attachment
       end
       new_attachment
     end

--- a/spec/models/no_cms/carrierwave/attachment_spec.rb
+++ b/spec/models/no_cms/carrierwave/attachment_spec.rb
@@ -98,11 +98,6 @@ describe NoCms::Carrierwave::Attachment do
 
     let!(:attachment) { NoCms::Carrierwave::Attachment.create(attachment_attributes) }
 
-    before do
-      # We have to stub the attachment_url, so the image can be duplicated
-      allow_any_instance_of(NoCms::Carrierwave::Attachment::Translation).to receive(:attachment_url).and_return('https://placeholdit.imgix.net/~text?txtsize=33&txt=350%C3%97150&w=350&h=150')
-    end
-
     subject { attachment.dup }
 
     it "should save" do


### PR DESCRIPTION
In environments with HTTP Auth (e.g. preproduction environments) remote_url
method couldn't be used.

We now use a simple duplication.
